### PR TITLE
Get DERIVATION_FILE using "nix edit"

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -41,7 +41,7 @@ git reset --hard
 git checkout master
 git reset --hard upstream/master
 
-DERIVATION_FILE=$(EDITOR=echo nix edit $1 -f . | sed 's|.*/nixpkgs/\(.*\)|\1|') || error_exit "Couldn't find derivation file."
+DERIVATION_FILE=$(EDITOR=echo nix edit $1 -f .) || error_exit "Couldn't find derivation file."
 
 function error_cleanup {
     cleanup

--- a/up.sh
+++ b/up.sh
@@ -41,7 +41,7 @@ git reset --hard
 git checkout master
 git reset --hard upstream/master
 
-DERIVATION_FILE=$(find . | grep "/$1/default.nix" | head -n1) || error_exit "Couldn't find derivation file."
+DERIVATION_FILE=$(EDITOR=echo nix edit $1 -f . | sed 's|.*/nixpkgs/\(.*\)|\1|') || error_exit "Couldn't find derivation file."
 
 function error_cleanup {
     cleanup


### PR DESCRIPTION
This is kind of a hack but it works pretty well. Previously the "attribute name" had to be the same as the directory name. This calls into Nix to evaluate the file that has the derivation.

@ryantm Hopefully this works okay on your machine.