### PR TITLE
Check that version is actually newer via compareVersions

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -23,6 +23,11 @@ function error_exit {
     exit 1
 }
 
+if ! [ $(nix-instantiate --eval -E "builtins.compareVersions '$NEW_VERSION' '$OLD_VERSION'") -eq  1 ];
+then
+    error_exit "$NEW_VERSION is not newer than $OLD_VERSION according to Nix"
+fi
+
 # Package blacklist
 case "$PACKAGE_NAME" in
     *jquery*) error_exit "this isn't a real package";;


### PR DESCRIPTION
This goes through Nix's old version upgrading system. It will error when the new version is not actually newer than the old version.